### PR TITLE
fix: ユーザー作成時にパスワードをハッシュ化して保存するように修正

### DIFF
--- a/app/backend/src/routes/api/v4/users/index.ts
+++ b/app/backend/src/routes/api/v4/users/index.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { Env, HonoApp } from "@/@types/hono";
 import type { FilteredUser, PaginatedResponse } from "@/@types/models";
 import { filterUser } from "@/lib/filter";
+import { hashPassword } from "@/lib/password";
 import { prisma } from "@/lib/prisma";
 import { createSession } from "@/lib/session";
 import { meRoute } from "@/routes/api/v4/users/me";
@@ -89,10 +90,11 @@ export const usersRoute = app
       return badRequest(c, "Username already exists");
     }
 
+    const hashedPassword = await hashPassword(password);
     const user = await prisma.user.create({
       data: {
         username,
-        password,
+        password: hashedPassword,
         name: name || username,
         role: "USER",
       },


### PR DESCRIPTION
## 概要
ユーザー作成時にパスワードが平文のままデータベースに保存されるセキュリティ問題を修正しました。

## 変更内容
- `hashPassword`関数を`@/lib/password`からインポート
- ユーザー作成処理でパスワードをハッシュ化してから保存
- 既存の認証フロー（`isPasswordValid`）との整合性を確保

## 影響範囲
- 新規ユーザー登録時のみ影響
- 既存ユーザーのパスワードは変更されません

## セキュリティ
この修正により、データベース侵害時でもパスワードが平文で漏洩するリスクを軽減します。