### PR TITLE
fix: パストラバーサル対策の実装

### DIFF
--- a/app/ffmpeg-worker/src/encoder.ts
+++ b/app/ffmpeg-worker/src/encoder.ts
@@ -186,9 +186,14 @@ const getDuration = async (filePath: string): Promise<number> => {
   });
 };
 
+const sanitizeFilename = (name: string): string => {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 255);
+};
+
 export const getLocalPath = (s3Key: string, suffix: string): string => {
   const filename = s3Key.split("/").pop() || "video";
-  return join(TEMP_DIR, `${filename}_${Date.now()}${suffix}`);
+  const sanitized = sanitizeFilename(filename);
+  return join(TEMP_DIR, `${sanitized}_${Date.now()}${suffix}`);
 };
 
 export const cleanup = (paths: string[]): void => {


### PR DESCRIPTION
## 概要

`getLocalPath`関数でS3キーから抽出したファイル名をサニタイズし、パストラバーサル攻撃を防止します。

## 変更内容

- `sanitizeFilename`関数を追加して危険な文字を除去
- `getLocalPath`関数でサニタイズされたファイル名を使用
- ファイル名の長さを255文字に制限

## セキュリティ改善

- パストラバーサル文字（`../`、`/`など）の除去
- 特殊文字のサニタイゼーション
- ファイル名長の制限によるバッファオーバーフロー対策

## 関連

セキュリティリスク: HIGH - パストラバーサルリスクを解消