### PR TITLE
fix: CSRF保護の改善 - credentials: includeを削除しBearer認証に統一

### DIFF
--- a/app/frontend/src/libraries/request.ts
+++ b/app/frontend/src/libraries/request.ts
@@ -1,11 +1,27 @@
+import { AuthTokenLocalStorageKey } from "@/atoms/Auth";
 import { ApiEndpoint } from "@/contexts/env";
 
 const request = async <T>(url: string, option: RequestInit = {}) => {
+  const storedToken =
+    typeof window !== "undefined"
+      ? localStorage.getItem(AuthTokenLocalStorageKey)
+      : null;
+  const token = storedToken
+    ? storedToken.startsWith('"')
+      ? storedToken.slice(1, -1)
+      : storedToken
+    : null;
+
+  const headers = new Headers(option.headers);
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
   const req = await fetch(`${ApiEndpoint}${url}`, {
     ...option,
     method: "POST",
     mode: "cors",
-    credentials: "include",
+    headers,
   });
   return (await req.json()) as T;
 };


### PR DESCRIPTION
## 概要
CSRF保護の欠如というセキュリティ問題を解決するため、フロントエンド全体で`credentials: "include"`を削除し、Bearer認証のみに統一しました。

## 変更内容
- `app/frontend/src/libraries/request.ts`から`credentials: "include"`を削除
- Bearer認証を使用するように変更（`client.ts`のパターンに合わせて実装）
- localStorageからトークンを取得し、Authorizationヘッダーに設定

## 影響範囲
- `app/frontend/src/components/Player/Shared/CommentCanvas.tsx` - コメント取得APIの呼び出しに影響

## セキュリティ
この変更により、CSRF攻撃のリスクを軽減します。Bearer認証のみを使用することで、Cookieベースの認証に伴うCSRF脆弱性を排除します。