### PR TITLE
security: require environment variables in production

### DIFF
--- a/app/backend/src/env.ts
+++ b/app/backend/src/env.ts
@@ -1,6 +1,26 @@
 import "dotenv/config";
 import * as process from "node:process";
 
+/**
+ * Requires an environment variable to be set.
+ * In development mode (NODE_ENV=development), allows a default value with a warning.
+ * In production mode, throws an error if the variable is not set.
+ */
+const requireEnv = (name: string, defaultForDev?: string): string => {
+  const value = process.env[name];
+  if (value) return value;
+
+  if (process.env.NODE_ENV === "development" && defaultForDev !== undefined) {
+    console.warn(`Warning: ${name} not set, using development default`);
+    return defaultForDev;
+  }
+
+  throw new Error(
+    `Required environment variable ${name} is not set. ` +
+      `Set it in your environment or use NODE_ENV=development for defaults.`,
+  );
+};
+
 export const PUBLIC_ENDPOINTS = process.env.PUBLIC_ENDPOINTS?.split(",") ?? [];
 export const CORS_ORIGIN = process.env.CORS_ORIGIN?.split(",") ?? [];
 export const PASSWORD_SALT = process.env.PASSWORD_SALT || "passwordsalt";
@@ -13,7 +33,7 @@ export const TOKEN_EXPIRY =
 export const SIGNUP_ENABLED = process.env.SIGNUP_ENABLED === "true";
 export const SIGNUP_CODE = process.env.SIGNUP_CODE;
 export const PORT = parseInt(process.env.PORT || "3000", 10);
-export const JWT_SECRET = process.env.JWT_SECRET || "secret";
+export const JWT_SECRET = requireEnv("JWT_SECRET", "dev-jwt-secret");
 
 // S3 Configuration
 export const S3_TMP_BUCKET = process.env.S3_TMP_BUCKET || "video-tmp";
@@ -33,6 +53,11 @@ export const REDIS_SENTINEL_PASSWORD = process.env.REDIS_SENTINEL_PASSWORD;
 
 // Video Processing
 export const VOD_BASE_URL = process.env.VOD_BASE_URL || "";
-export const CALLBACK_SECRET = process.env.CALLBACK_SECRET || "callback-secret";
-export const VOD_INTERNAL_SECRET =
-  process.env.VOD_INTERNAL_SECRET || "vod-internal-secret";
+export const CALLBACK_SECRET = requireEnv(
+  "CALLBACK_SECRET",
+  "dev-callback-secret",
+);
+export const VOD_INTERNAL_SECRET = requireEnv(
+  "VOD_INTERNAL_SECRET",
+  "dev-vod-internal-secret",
+);

--- a/app/ffmpeg-worker/src/callback.ts
+++ b/app/ffmpeg-worker/src/callback.ts
@@ -1,9 +1,5 @@
 import { client } from "./client";
-
-const CALLBACK_SECRET = process.env.CALLBACK_SECRET;
-if (!CALLBACK_SECRET) {
-  throw new Error("SECRET is not defined");
-}
+import { CALLBACK_SECRET } from "./env";
 
 export interface CallbackPayload {
   movieId: string;

--- a/app/ffmpeg-worker/src/env.ts
+++ b/app/ffmpeg-worker/src/env.ts
@@ -1,5 +1,25 @@
 import "dotenv/config";
 
+/**
+ * Requires an environment variable to be set.
+ * In development mode (NODE_ENV=development), allows a default value with a warning.
+ * In production mode, throws an error if the variable is not set.
+ */
+const requireEnv = (name: string, defaultForDev?: string): string => {
+  const value = process.env[name];
+  if (value) return value;
+
+  if (process.env.NODE_ENV === "development" && defaultForDev !== undefined) {
+    console.warn(`Warning: ${name} not set, using development default`);
+    return defaultForDev;
+  }
+
+  throw new Error(
+    `Required environment variable ${name} is not set. ` +
+    `Set it in your environment or use NODE_ENV=development for defaults.`,
+  );
+};
+
 export const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
 // Sentinel Configuration (optional)
 export const REDIS_SENTINEL_HOSTS = process.env.REDIS_SENTINEL_HOSTS; // e.g., "host1:26379,host2:26379,host3:26379"
@@ -19,7 +39,10 @@ export const S3_FORCE_PATH_STYLE = process.env.S3_FORCE_PATH_STYLE === "true";
 export const BACKEND_CALLBACK_URL =
   process.env.BACKEND_CALLBACK_URL ||
   "http://localhost:3001/api/v4/callback/encode-complete";
-export const CALLBACK_SECRET = process.env.CALLBACK_SECRET || "callback-secret";
+export const CALLBACK_SECRET = requireEnv(
+  "CALLBACK_SECRET",
+  "dev-callback-secret",
+);
 
 // VOD streaming
 export const VOD_BASE_URL = process.env.VOD_BASE_URL || "http://localhost:3002";

--- a/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
+++ b/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
@@ -22,7 +22,10 @@ This document must be maintained in accordance with `.agent/PLANS.md`.
 
 ## Progress
 
-- [ ] Milestone 1: 必須環境変数のバリデーション追加
+- [x] (2025-12-31 04:40 JST) Milestone 1: 必須環境変数のバリデーション追加
+  - Added `requireEnv` helper function to `app/backend/src/env.ts`
+  - Applied to JWT_SECRET, CALLBACK_SECRET, VOD_INTERNAL_SECRET
+  - Verified: production mode throws error; development mode uses defaults with warnings
 - [ ] Milestone 2: Authorizationヘッダー解析の修正
 - [ ] Milestone 3: S3キーのパス・トラバーサル対策
 - [ ] Milestone 4: ユニットテスト基盤の構築


### PR DESCRIPTION
## Summary

Add `requireEnv` helper function that enforces required environment variables in production environments.

## Changes

- Added `requireEnv(name, defaultForDev?)` helper function to `app/backend/src/env.ts`
- Applied to security-critical variables:
  - `JWT_SECRET`
  - `CALLBACK_SECRET`
  - `VOD_INTERNAL_SECRET`

## Behavior

| Mode | Environment Variable Set | Behavior |
|------|-------------------------|----------|
| Production (`NODE_ENV=production`) | ❌ Not set | 🚫 Throws error, server won't start |
| Production (`NODE_ENV=production`) | ✅ Set | ✅ Uses provided value |
| Development (`NODE_ENV=development`) | ❌ Not set | ⚠️ Warning + uses default |
| Development (`NODE_ENV=development`) | ✅ Set | ✅ Uses provided value |

## Motivation

Previously, security-critical secrets had hardcoded defaults (e.g., `"secret"`, `"callback-secret"`). If an operator forgot to set environment variables in production, the server would run with these insecure defaults, creating a security vulnerability.

## Related

- ExecPlan: `z/2025-12-31-EXECPLAN-security-and-quality-fixes.md` (Milestone 1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened S3 key validation to block path traversal and injection attempts.
  * Enforced required environment variables: missing values error in production, development uses safe fallbacks with warnings.
  * Improved Authorization header parsing for stricter token extraction.

* **Infrastructure**
  * Added testing framework and unit tests to improve reliability.

* **Bug Fixes**
  * Centralized secret initialization to ensure callbacks receive configured secrets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->