### PR TITLE
fix(vod): add S3 key validation to prevent path traversal attacks

### DIFF
--- a/app/backend/src/routes/api/v4/vod.ts
+++ b/app/backend/src/routes/api/v4/vod.ts
@@ -13,23 +13,28 @@ import { unauthorized } from "@/utils/response";
  * @returns true if the key is valid, false otherwise
  */
 export const isValidS3Key = (key: string): boolean => {
-  // Reject empty keys
-  if (!key) {
+  try {
+    const decoded = decodeURIComponent(key);
+    // Reject empty keys
+    if (!decoded) {
+      return false;
+    }
+    // Reject absolute paths
+    if (decoded.startsWith("/")) {
+      return false;
+    }
+    // Reject parent directory references (path traversal)
+    if (decoded.includes("..")) {
+      return false;
+    }
+    // Reject null byte injection
+    if (decoded.includes("\0")) {
+      return false;
+    }
+    return true;
+  } catch {
     return false;
   }
-  // Reject absolute paths
-  if (key.startsWith("/")) {
-    return false;
-  }
-  // Reject parent directory references (path traversal)
-  if (key.includes("..")) {
-    return false;
-  }
-  // Reject null byte injection
-  if (key.includes("\0")) {
-    return false;
-  }
-  return true;
 };
 
 const app = new Hono<Env>();

--- a/app/backend/src/routes/api/v4/vod.ts
+++ b/app/backend/src/routes/api/v4/vod.ts
@@ -6,6 +6,32 @@ import { S3_PROD_BUCKET, VOD_INTERNAL_SECRET } from "@/env";
 import { s3Client } from "@/lib/s3";
 import { unauthorized } from "@/utils/response";
 
+/**
+ * Validates an S3 key to prevent path traversal attacks.
+ * Rejects empty keys, absolute paths, parent directory references, and null byte injection.
+ * @param key - The S3 key to validate
+ * @returns true if the key is valid, false otherwise
+ */
+export const isValidS3Key = (key: string): boolean => {
+  // Reject empty keys
+  if (!key) {
+    return false;
+  }
+  // Reject absolute paths
+  if (key.startsWith("/")) {
+    return false;
+  }
+  // Reject parent directory references (path traversal)
+  if (key.includes("..")) {
+    return false;
+  }
+  // Reject null byte injection
+  if (key.includes("\0")) {
+    return false;
+  }
+  return true;
+};
+
 const app = new Hono<Env>();
 
 // VOD mapping endpoint for nginx-vod-module
@@ -25,6 +51,11 @@ export const vodRoute = app.get("/mapping/*", async (c) => {
 
   if (!s3Key) {
     return c.json({ error: "Missing s3Key" }, 400);
+  }
+
+  // Validate S3 key to prevent path traversal attacks
+  if (!isValidS3Key(s3Key)) {
+    return c.json({ error: "Invalid s3Key" }, 400);
   }
 
   // Generate presigned GET URL for the S3 object

--- a/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
+++ b/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
@@ -31,7 +31,11 @@ This document must be maintained in accordance with `.agent/PLANS.md`.
   - Final code: `c.req.header("authorization")?.match(/^Bearer\s+(\S+)$/i)?.[1]`
   - Uses `\S+` to exclude trailing whitespace (code review feedback)
   - PR #8 merged into master
-- [ ] Milestone 3: S3キーのパス・トラバーサル対策
+- [x] (2025-12-31 05:20 JST) Milestone 3: S3キーのパス・トラバーサル対策
+  - Added `isValidS3Key` validation function to `app/backend/src/routes/api/v4/vod.ts`
+  - Rejects: empty keys, absolute paths (`/`), parent directory references (`..`), null bytes (`\0`)
+  - Function exported for unit testing
+  - TypeScript compilation passed
 - [ ] Milestone 4: ユニットテスト基盤の構築
 - [ ] Milestone 5: 認証・セキュリティロジックのテスト追加
 


### PR DESCRIPTION
## Summary

VODマッピングエンドポイントにS3キーの検証ロジックを追加し、パストラバーサル攻撃を防止します。

## Changes

`app/backend/src/routes/api/v4/vod.ts` に `isValidS3Key` 関数を追加:

- 空のキーを拒否
- 絶対パス (`/`で始まる) を拒否
- 親ディレクトリ参照 (`..`) を拒否（パストラバーサル攻撃防止）
- NULLバイトインジェクション (`\0`) を拒否

## Security Impact

攻撃者が `../../../etc/passwd` のような細工されたパスを送信して、意図しないS3オブジェクトにアクセスすることを防止します。

## Testing

- [x] TypeScript型チェック通過
- [ ] ユニットテスト (Milestone 4/5で追加予定)

## Related

- Milestone 3 of `z/2025-12-31-EXECPLAN-security-and-quality-fixes.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced storage/security validation for object keys. The API now rejects empty or malformed keys — including absolute paths, parent-directory traversal, and embedded null bytes — and returns an error for invalid keys before generating access links, reducing risk of unauthorized access or path-based attacks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->