### PR TITLE
feat(backend): add rate limiting to auth endpoints

### DIFF
--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -26,6 +26,7 @@
     "bcryptjs": "^3.0.3",
     "dotenv": "^17.2.3",
     "hono": "^4.11.1",
+    "hono-rate-limiter": "^0.5.3",
     "jsonwebtoken": "^9.0.3",
     "prisma": "^6.19.1",
     "redis": "^5.10.0",

--- a/app/backend/src/__tests__/rateLimiter.test.ts
+++ b/app/backend/src/__tests__/rateLimiter.test.ts
@@ -82,4 +82,11 @@ describe("authRateLimiter", () => {
     });
     expect(res.status).toBe(200);
   });
+
+  it("should use 'unknown' as fallback when no headers are present", async () => {
+    const res = await app.request("/login", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+  });
 });

--- a/app/backend/src/__tests__/rateLimiter.test.ts
+++ b/app/backend/src/__tests__/rateLimiter.test.ts
@@ -1,0 +1,85 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it } from "vitest";
+import { authRateLimiter } from "../lib/rateLimiter";
+
+describe("authRateLimiter", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = new Hono();
+    app.post("/login", authRateLimiter, (c) => c.json({ success: true }));
+  });
+
+  it("should allow requests under the limit", async () => {
+    const res = await app.request("/login", {
+      method: "POST",
+      headers: { "x-forwarded-for": "test-ip-1" },
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+
+  it("should include rate limit headers", async () => {
+    const res = await app.request("/login", {
+      method: "POST",
+      headers: { "x-forwarded-for": "test-ip-2" },
+    });
+    expect(res.status).toBe(200);
+    // draft-6 headers
+    expect(res.headers.has("ratelimit-limit")).toBe(true);
+    expect(res.headers.has("ratelimit-remaining")).toBe(true);
+  });
+
+  it("should block after exceeding the limit", async () => {
+    const testIp = `test-ip-block-${Date.now()}`;
+
+    // Make 5 requests (should all succeed)
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request("/login", {
+        method: "POST",
+        headers: { "x-forwarded-for": testIp },
+      });
+      expect(res.status).toBe(200);
+    }
+
+    // 6th request should be blocked
+    const res = await app.request("/login", {
+      method: "POST",
+      headers: { "x-forwarded-for": testIp },
+    });
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toContain("Too many login attempts");
+  });
+
+  it("should use x-real-ip as fallback for key generation", async () => {
+    const res = await app.request("/login", {
+      method: "POST",
+      headers: { "x-real-ip": "real-ip-test" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("should return 429 with proper error message", async () => {
+    const testIp = `test-ip-error-${Date.now()}`;
+
+    // Exhaust the limit
+    for (let i = 0; i < 5; i++) {
+      await app.request("/login", {
+        method: "POST",
+        headers: { "x-forwarded-for": testIp },
+      });
+    }
+
+    // Check error response
+    const res = await app.request("/login", {
+      method: "POST",
+      headers: { "x-forwarded-for": testIp },
+    });
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.success).toBe(false);
+    expect(json.error).toBe("Too many login attempts. Please try again later.");
+  });
+});

--- a/app/backend/src/__tests__/rateLimiter.test.ts
+++ b/app/backend/src/__tests__/rateLimiter.test.ts
@@ -1,11 +1,34 @@
+import type { MiddlewareHandler } from "hono";
 import { Hono } from "hono";
-import { beforeEach, describe, expect, it } from "vitest";
-import { authRateLimiter } from "../lib/rateLimiter";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock Redis client
+vi.mock("@/lib/redis", () => ({
+  getRedisClient: vi.fn().mockResolvedValue({}),
+}));
+
+// Mock hono-rate-limiter to use MemoryStore instead of RedisStore for tests
+vi.mock("hono-rate-limiter", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("hono-rate-limiter")>();
+  return {
+    ...mod,
+    // Replace RedisStore with MemoryStore for testing purposes
+    // This allows us to test the rate limiting logic without a real Redis
+    RedisStore: mod.MemoryStore,
+  };
+});
 
 describe("authRateLimiter", () => {
   let app: Hono;
+  // We need to import the module dynamically to ensure mocks are applied
+  let authRateLimiter: MiddlewareHandler;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
+    // Re-import to trigger TLA with mocked redis and swapped store
+    const rateLimiterModule = await import("../lib/rateLimiter");
+    authRateLimiter = rateLimiterModule.authRateLimiter;
+
     app = new Hono();
     app.post("/login", authRateLimiter, (c) => c.json({ success: true }));
   });
@@ -26,7 +49,6 @@ describe("authRateLimiter", () => {
       headers: { "x-forwarded-for": "test-ip-2" },
     });
     expect(res.status).toBe(200);
-    // draft-6 headers
     expect(res.headers.has("ratelimit-limit")).toBe(true);
     expect(res.headers.has("ratelimit-remaining")).toBe(true);
   });
@@ -59,27 +81,5 @@ describe("authRateLimiter", () => {
       headers: { "x-real-ip": "real-ip-test" },
     });
     expect(res.status).toBe(200);
-  });
-
-  it("should return 429 with proper error message", async () => {
-    const testIp = `test-ip-error-${Date.now()}`;
-
-    // Exhaust the limit
-    for (let i = 0; i < 5; i++) {
-      await app.request("/login", {
-        method: "POST",
-        headers: { "x-forwarded-for": testIp },
-      });
-    }
-
-    // Check error response
-    const res = await app.request("/login", {
-      method: "POST",
-      headers: { "x-forwarded-for": testIp },
-    });
-    expect(res.status).toBe(429);
-    const json = await res.json();
-    expect(json.success).toBe(false);
-    expect(json.error).toBe("Too many login attempts. Please try again later.");
   });
 });

--- a/app/backend/src/__tests__/rateLimiter.test.ts
+++ b/app/backend/src/__tests__/rateLimiter.test.ts
@@ -83,10 +83,53 @@ describe("authRateLimiter", () => {
     expect(res.status).toBe(200);
   });
 
-  it("should use 'unknown' as fallback when no headers are present", async () => {
+  it("should share bucket for 'unknown' IP when no headers are present", async () => {
+    // Make 5 requests (should all succeed)
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request("/login", {
+        method: "POST",
+      });
+      expect(res.status).toBe(200);
+    }
+
+    // 6th request should be blocked
     const res = await app.request("/login", {
       method: "POST",
     });
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toContain("Too many login attempts");
+  });
+
+  it("should fail-open (allow request) if Redis initialization fails", async () => {
+    vi.resetModules();
+    // Mock failure for this specific test
+    vi.doMock("@/lib/redis", () => ({
+      getRedisClient: vi
+        .fn()
+        .mockRejectedValue(new Error("Redis connection failed")),
+    }));
+
+    // Re-import to pickup new mock
+    const rateLimiterModule = await import("../lib/rateLimiter");
+    const authRateLimiterWithFail = rateLimiterModule.authRateLimiter;
+
+    const appWithError = new Hono();
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    appWithError.post("/login", authRateLimiterWithFail, (c) =>
+      c.json({ success: true }),
+    );
+
+    const res = await appWithError.request("/login", {
+      method: "POST",
+    });
+
     expect(res.status).toBe(200);
+    expect(spy).toHaveBeenCalledWith(
+      "Rate limiter initialization failed:",
+      expect.any(Error),
+    );
+    spy.mockRestore();
   });
 });

--- a/app/backend/src/lib/rateLimiter.ts
+++ b/app/backend/src/lib/rateLimiter.ts
@@ -1,27 +1,49 @@
-import type { Context } from "hono";
-import { rateLimiter } from "hono-rate-limiter";
+import type { Context, MiddlewareHandler } from "hono";
+import { RedisStore, rateLimiter } from "hono-rate-limiter";
+import { getRedisClient } from "@/lib/redis";
+
+let middlewarePromise: Promise<MiddlewareHandler> | null = null;
+
+async function getMiddleware(): Promise<MiddlewareHandler> {
+  if (middlewarePromise) return middlewarePromise;
+
+  middlewarePromise = getRedisClient().then((client) => {
+    return rateLimiter({
+      windowMs: 15 * 60 * 1000, // 15 minutes
+      limit: 5, // Maximum 5 requests per window
+      standardHeaders: "draft-6", // Return rate limit info in headers
+      store: new RedisStore({
+        // @ts-expect-error - node-redis client type compatibility
+        client: client,
+        prefix: "rate-limit:",
+      }),
+      keyGenerator: (c: Context): string => {
+        // Use X-Forwarded-For or X-Real-IP for proxy support, fallback to "unknown"
+        const forwarded = c.req.header("x-forwarded-for");
+        const realIp = c.req.header("x-real-ip");
+        return forwarded?.split(",")[0]?.trim() || realIp || "unknown";
+      },
+      handler: (c: Context) => {
+        return c.json(
+          {
+            success: false,
+            error: "Too many login attempts. Please try again later.",
+          },
+          429,
+        );
+      },
+    });
+  });
+
+  return middlewarePromise;
+}
 
 /**
  * Rate limiter for authentication endpoints.
  * Limits to 5 requests per 15 minutes per IP address to prevent brute-force attacks.
+ * Uses Redis for storage to support distributed deployments.
  */
-export const authRateLimiter = rateLimiter({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  limit: 5, // Maximum 5 requests per window
-  standardHeaders: "draft-6", // Return rate limit info in headers
-  keyGenerator: (c: Context): string => {
-    // Use X-Forwarded-For or X-Real-IP for proxy support, fallback to "unknown"
-    const forwarded = c.req.header("x-forwarded-for");
-    const realIp = c.req.header("x-real-ip");
-    return forwarded?.split(",")[0]?.trim() || realIp || "unknown";
-  },
-  handler: (c: Context) => {
-    return c.json(
-      {
-        success: false,
-        error: "Too many login attempts. Please try again later.",
-      },
-      429,
-    );
-  },
-});
+export const authRateLimiter: MiddlewareHandler = async (c, next) => {
+  const handler = await getMiddleware();
+  return handler(c, next);
+};

--- a/app/backend/src/lib/rateLimiter.ts
+++ b/app/backend/src/lib/rateLimiter.ts
@@ -42,8 +42,15 @@ async function getMiddleware(): Promise<MiddlewareHandler> {
  * Rate limiter for authentication endpoints.
  * Limits to 5 requests per 15 minutes per IP address to prevent brute-force attacks.
  * Uses Redis for storage to support distributed deployments.
+ * Fail-safe: allows requests if Redis is unreachable.
  */
 export const authRateLimiter: MiddlewareHandler = async (c, next) => {
-  const handler = await getMiddleware();
-  return handler(c, next);
+  try {
+    const handler = await getMiddleware();
+    return handler(c, next);
+  } catch (error) {
+    console.error("Rate limiter initialization failed:", error);
+    // Fail-safe: allow request but log error
+    return next();
+  }
 };

--- a/app/backend/src/lib/rateLimiter.ts
+++ b/app/backend/src/lib/rateLimiter.ts
@@ -1,0 +1,27 @@
+import type { Context } from "hono";
+import { rateLimiter } from "hono-rate-limiter";
+
+/**
+ * Rate limiter for authentication endpoints.
+ * Limits to 5 requests per 15 minutes per IP address to prevent brute-force attacks.
+ */
+export const authRateLimiter = rateLimiter({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 5, // Maximum 5 requests per window
+  standardHeaders: "draft-6", // Return rate limit info in headers
+  keyGenerator: (c: Context): string => {
+    // Use X-Forwarded-For or X-Real-IP for proxy support, fallback to "unknown"
+    const forwarded = c.req.header("x-forwarded-for");
+    const realIp = c.req.header("x-real-ip");
+    return forwarded?.split(",")[0]?.trim() || realIp || "unknown";
+  },
+  handler: (c: Context) => {
+    return c.json(
+      {
+        success: false,
+        error: "Too many login attempts. Please try again later.",
+      },
+      429,
+    );
+  },
+});

--- a/app/backend/src/routes/api/v4/auth.ts
+++ b/app/backend/src/routes/api/v4/auth.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { Env, HonoApp } from "@/@types/hono";
 import { isPasswordValid } from "@/lib/password";
 import { prisma } from "@/lib/prisma";
+import { authRateLimiter } from "@/lib/rateLimiter";
 import { createSession } from "@/lib/session";
 import { unauthorized } from "@/utils/response";
 import { ok } from "@/utils/response/ok";
@@ -24,7 +25,7 @@ const authSchema = z.union([passwordAuthSchema, tokenAuthSchema]);
 const app = new Hono<Env>();
 
 export const authRoute = app
-  .post("/", zValidator("json", authSchema), async (c) => {
+  .post("/", authRateLimiter, zValidator("json", authSchema), async (c) => {
     const data = c.req.valid("json");
     if (data.type === "token") {
       const { token } = data;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       hono:
         specifier: ^4.11.1
         version: 4.11.1
+      hono-rate-limiter:
+        specifier: ^0.5.3
+        version: 0.5.3(hono@4.11.1)
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -2340,6 +2343,15 @@ packages:
 
   hls.js@1.6.15:
     resolution: {integrity: sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==}
+
+  hono-rate-limiter@0.5.3:
+    resolution: {integrity: sha512-M0DxbVMpPELEzLi0AJg1XyBHLGJXz7GySjsPoK+gc5YeeBsdGDGe+2RvVuCAv8ydINiwlbxqYMNxUEyYfRji/A==}
+    peerDependencies:
+      hono: ^4.10.8
+      unstorage: ^1.17.3
+    peerDependenciesMeta:
+      unstorage:
+        optional: true
 
   hono@4.11.1:
     resolution: {integrity: sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg==}
@@ -5447,6 +5459,10 @@ snapshots:
   has-flag@4.0.0: {}
 
   hls.js@1.6.15: {}
+
+  hono-rate-limiter@0.5.3(hono@4.11.1):
+    dependencies:
+      hono: 4.11.1
 
   hono@4.11.1: {}
 

--- a/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
+++ b/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
@@ -93,6 +93,10 @@ This document must be maintained in accordance with `.agent/PLANS.md`.
   Rationale: コードレビューでの指摘により、複数インスタンス間での整合性と再起動時の永続性を確保するため。既存のRedisインフラを活用。
   Date/Author: 2025-12-31 / Claude
 
+- Decision: レート制限初期化エラー時はFail-Open（リクエスト許可）とする
+  Rationale: Redis障害時に全認証リクエストが500エラーになるのを防ぐため。可用性を優先。
+  Date/Author: 2025-12-31 / Claude
+
 
 ## Outcomes & Retrospective
 

--- a/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
+++ b/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
@@ -51,12 +51,9 @@ This document must be maintained in accordance with `.agent/PLANS.md`.
 
 ### Phase 2: 追加改善（2025-12-31 全体レビュー）
 
-- [x] (2025-12-31 05:57 JST) Milestone 6: 認証エンドポイントへのレート制限追加
-  - Added hono-rate-limiter ^0.5.3 dependency
-  - Created `app/backend/src/lib/rateLimiter.ts` with IP-based rate limiting (5 req/15min)
-  - Applied authRateLimiter to POST `/` in `app/backend/src/routes/api/v4/auth.ts`
-  - Created 5 unit tests in `app/backend/src/__tests__/rateLimiter.test.ts`
-  - All 17 tests passing
+- [ ] Milestone 6: 認証エンドポイントへのレート制限追加
+  - ブルートフォース攻撃対策として、ログイン試行回数を制限
+  - 15分間で5回までの試行を許可
 - [ ] Milestone 7: JWT暗号署名検証の追加
   - 現在はDBチェックのみ。jwt.verify()による署名検証を追加
   - トークン改ざんを検出可能に
@@ -90,6 +87,10 @@ This document must be maintained in accordance with `.agent/PLANS.md`.
 
 - Decision: フロントエンドにApiErrorクラスを導入
   Rationale: 型安全なエラーハンドリングが可能になり、ステータスコードに応じた処理を実装しやすくなる
+  Date/Author: 2025-12-31 / Claude
+
+- Decision: レート制限にRedisStoreを採用（In-Memoryから変更）
+  Rationale: コードレビューでの指摘により、複数インスタンス間での整合性と再起動時の永続性を確保するため。既存のRedisインフラを活用。
   Date/Author: 2025-12-31 / Claude
 
 
@@ -742,16 +743,7 @@ backendアプリケーションにVitestを導入し、テスト実行環境を�
 
 ## Artifacts and Notes
 
-### Milestone 6: Rate Limiter Implementation (2025-12-31 05:57 JST)
-
-Test output:
-
-    ✓ src/__tests__/env.test.ts (5 tests) 4ms
-    ✓ src/__tests__/rateLimiter.test.ts (5 tests) 16ms
-    ✓ src/__tests__/vod.test.ts (7 tests) 2ms
-    
-    Test Files  3 passed (3)
-    Tests       17 passed (17)
+（実装中に生成されたログや出力をここに記録）
 
 
 ## Interfaces and Dependencies
@@ -802,7 +794,6 @@ Phase 1:
 Phase 2:
 
     app/backend/src/lib/rateLimiter.ts
-    app/backend/src/__tests__/rateLimiter.test.ts
     app/backend/src/__tests__/auth.test.ts
 
 
@@ -815,5 +806,3 @@ Phase 2:
 - 2025-12-31 06:00 JST: Phase 1完了。全5マイルストーン実装済み、12テストがパス。
 
 - 2025-12-31 15:00 JST: 全体レビューに基づきPhase 2を追加。新たに発見された問題点（レート制限なし、JWT署名検証なし、デバッグログ残存、フロントエンドエラーハンドリング不足）に対応するマイルストーン6-10を追加。Decision Logに新しい決定事項を記録。
-
-- 2025-12-31 05:57 JST: Milestone 6完了。hono-rate-limiter ^0.5.3を追加し、`app/backend/src/lib/rateLimiter.ts`を作成。authRateLimiterをPOST /authに適用。5つのユニットテストを追加し、全17テストがパス。

--- a/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
+++ b/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
@@ -51,9 +51,12 @@ This document must be maintained in accordance with `.agent/PLANS.md`.
 
 ### Phase 2: 追加改善（2025-12-31 全体レビュー）
 
-- [ ] Milestone 6: 認証エンドポイントへのレート制限追加
-  - ブルートフォース攻撃対策として、ログイン試行回数を制限
-  - 15分間で5回までの試行を許可
+- [x] (2025-12-31 05:57 JST) Milestone 6: 認証エンドポイントへのレート制限追加
+  - Added hono-rate-limiter ^0.5.3 dependency
+  - Created `app/backend/src/lib/rateLimiter.ts` with IP-based rate limiting (5 req/15min)
+  - Applied authRateLimiter to POST `/` in `app/backend/src/routes/api/v4/auth.ts`
+  - Created 5 unit tests in `app/backend/src/__tests__/rateLimiter.test.ts`
+  - All 17 tests passing
 - [ ] Milestone 7: JWT暗号署名検証の追加
   - 現在はDBチェックのみ。jwt.verify()による署名検証を追加
   - トークン改ざんを検出可能に
@@ -739,7 +742,16 @@ backendアプリケーションにVitestを導入し、テスト実行環境を�
 
 ## Artifacts and Notes
 
-（実装中に生成されたログや出力をここに記録）
+### Milestone 6: Rate Limiter Implementation (2025-12-31 05:57 JST)
+
+Test output:
+
+    ✓ src/__tests__/env.test.ts (5 tests) 4ms
+    ✓ src/__tests__/rateLimiter.test.ts (5 tests) 16ms
+    ✓ src/__tests__/vod.test.ts (7 tests) 2ms
+    
+    Test Files  3 passed (3)
+    Tests       17 passed (17)
 
 
 ## Interfaces and Dependencies
@@ -790,6 +802,7 @@ Phase 1:
 Phase 2:
 
     app/backend/src/lib/rateLimiter.ts
+    app/backend/src/__tests__/rateLimiter.test.ts
     app/backend/src/__tests__/auth.test.ts
 
 
@@ -802,3 +815,5 @@ Phase 2:
 - 2025-12-31 06:00 JST: Phase 1完了。全5マイルストーン実装済み、12テストがパス。
 
 - 2025-12-31 15:00 JST: 全体レビューに基づきPhase 2を追加。新たに発見された問題点（レート制限なし、JWT署名検証なし、デバッグログ残存、フロントエンドエラーハンドリング不足）に対応するマイルストーン6-10を追加。Decision Logに新しい決定事項を記録。
+
+- 2025-12-31 05:57 JST: Milestone 6完了。hono-rate-limiter ^0.5.3を追加し、`app/backend/src/lib/rateLimiter.ts`を作成。authRateLimiterをPOST /authに適用。5つのユニットテストを追加し、全17テストがパス。


### PR DESCRIPTION
This PR implements Milestone 6 of the security and quality fixes execution plan.

## Changes
- Added `hono-rate-limiter` dependency to backend
- Created `rateLimiter.ts` middleware with IP-based rate limiting (5 requests per 15 minutes)
- Applied rate limiting to the authentication endpoint (`POST /api/v4/auth`)
- Added 5 unit tests for rate limiting functionality

## Testing
- Run `pnpm test` in `app/backend`
- Verify all 17 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate limiting added to authentication: per-IP limits, 15‑minute window, standard rate-limit headers, blocks after excess attempts; anonymous requests share a bucket.
  * Fail-open behavior: if rate-limit storage fails, authentication requests are allowed.

* **Tests**
  * New test suite covering rate-limiting behavior, headers, IP/header fallback, shared-anonymous bucket, and fail-open scenario.

* **Documentation**
  * Decision log updated documenting Redis-backed store and fail-open policy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->