### PR TITLE
feat(auth): add JWT signature verification before DB query

### DIFF
--- a/app/backend/src/__tests__/jwt.test.ts
+++ b/app/backend/src/__tests__/jwt.test.ts
@@ -1,0 +1,66 @@
+import jwt from "jsonwebtoken";
+import { describe, expect, it } from "vitest";
+import { JWT_SECRET } from "../env";
+
+/**
+ * Tests for JWT token verification logic.
+ * These tests validate the jwt.verify() behavior that is used in the auth middleware.
+ */
+describe("JWT verification", () => {
+  const testUserId = "test-user-123";
+  const testExpiredAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // 7 days from now
+
+  it("should verify a valid token", () => {
+    const token = jwt.sign(
+      { userId: testUserId, expiredAt: testExpiredAt },
+      JWT_SECRET,
+    );
+
+    expect(() => jwt.verify(token, JWT_SECRET)).not.toThrow();
+    const decoded = jwt.verify(token, JWT_SECRET) as { userId: string };
+    expect(decoded.userId).toBe(testUserId);
+  });
+
+  it("should reject a token with modified payload", () => {
+    const token = jwt.sign(
+      { userId: testUserId, expiredAt: testExpiredAt },
+      JWT_SECRET,
+    );
+
+    // Modify the payload by changing a character in the middle
+    const parts = token.split(".");
+    const modifiedPayload = parts[1].replace(/./g, (c, i) =>
+      i === 5 ? (c === "a" ? "b" : "a") : c,
+    );
+    const modifiedToken = `${parts[0]}.${modifiedPayload}.${parts[2]}`;
+
+    expect(() => jwt.verify(modifiedToken, JWT_SECRET)).toThrow();
+  });
+
+  it("should reject a token signed with wrong secret", () => {
+    const token = jwt.sign(
+      { userId: testUserId, expiredAt: testExpiredAt },
+      "wrong-secret",
+    );
+
+    expect(() => jwt.verify(token, JWT_SECRET)).toThrow();
+  });
+
+  it("should reject a token with modified signature", () => {
+    const token = jwt.sign(
+      { userId: testUserId, expiredAt: testExpiredAt },
+      JWT_SECRET,
+    );
+
+    // Modify the signature
+    const modifiedToken = `${token.slice(0, -5)}XXXXX`;
+
+    expect(() => jwt.verify(modifiedToken, JWT_SECRET)).toThrow();
+  });
+
+  it("should reject malformed tokens", () => {
+    expect(() => jwt.verify("not-a-jwt", JWT_SECRET)).toThrow();
+    expect(() => jwt.verify("a.b.c", JWT_SECRET)).toThrow();
+    expect(() => jwt.verify("", JWT_SECRET)).toThrow();
+  });
+});

--- a/app/backend/src/middleware/auth.ts
+++ b/app/backend/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from "hono/factory";
+import jwt from "jsonwebtoken";
 import type { HonoApp } from "@/@types/hono";
-import { PUBLIC_ENDPOINTS } from "@/env";
+import { JWT_SECRET, PUBLIC_ENDPOINTS } from "@/env";
 import { prisma } from "@/lib/prisma";
 import { unauthorized } from "@/utils/response";
 
@@ -27,6 +28,18 @@ const authMiddleware = createMiddleware<{
     }
     return unauthorized(c, "Unauthorized");
   }
+
+  // JWT signature verification (before DB query to reject invalid tokens early)
+  try {
+    jwt.verify(token, JWT_SECRET);
+  } catch {
+    if (isPublicEndpoint(url)) {
+      await next();
+      return;
+    }
+    return unauthorized(c, "Invalid token signature");
+  }
+
   const session = await prisma.session.findFirst({
     where: {
       token,

--- a/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
+++ b/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
@@ -57,9 +57,11 @@ This document must be maintained in accordance with `.agent/PLANS.md`.
   - Implemented lazy initialization and fail-open policy for robustness
   - Created `app/backend/src/__tests__/rateLimiter.test.ts` with 6 unit tests (mocked Redis)
   - Verified: 18/18 tests passed
-- [ ] Milestone 7: JWT暗号署名検証の追加
-  - 現在はDBチェックのみ。jwt.verify()による署名検証を追加
-  - トークン改ざんを検出可能に
+- [x] (2025-12-31 14:32 JST) Milestone 7: JWT暗号署名検証の追加
+  - Added `jwt.verify()` before DB query in `app/backend/src/middleware/auth.ts`
+  - Returns "Invalid token signature" error for tampered/invalid tokens
+  - Created `app/backend/src/__tests__/jwt.test.ts` with 5 test cases
+  - Verified: 23/23 tests passed
 - [ ] Milestone 8: デバッグログの削除
   - `app/backend/src/routes/api/v4/vod.ts:93` の console.log を削除
 - [ ] Milestone 9: フロントエンドAPIエラーハンドリング改善


### PR DESCRIPTION
## Summary

Milestone 7 of security and quality fixes: Add JWT cryptographic signature verification to the authentication middleware.

## Changes

- ****: 
  - Added `jwt.verify()` before database lookup to detect tampered tokens early
  - Imported `jsonwebtoken` and `JWT_SECRET`
  - Returns "Invalid token signature" error for invalid/tampered tokens

- **** (new):
  - 5 test cases covering valid tokens, modified payloads, wrong secrets, modified signatures, and malformed tokens

## Testing

```
✓ src/__tests__/env.test.ts (5 tests)
✓ src/__tests__/rateLimiter.test.ts (6 tests)
✓ src/__tests__/jwt.test.ts (5 tests)
✓ src/__tests__/vod.test.ts (7 tests)

Test Files  4 passed (4)
Tests       23 passed (23)
```

## Related

Part of [ExecPlan: security-and-quality-fixes](z/2025-12-31-EXECPLAN-security-and-quality-fixes.md) Milestone 7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * Implemented JWT cryptographic signature verification early in the authentication flow to reject invalid or tampered tokens immediately.

* **Tests**
  * Added comprehensive test suite for JWT token validation, covering valid tokens, modified payloads, incorrect secrets, and malformed token scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->