### PR TITLE
fix: remove debug console.log from VOD mapping endpoint

### DIFF
--- a/app/backend/src/routes/api/v4/vod.ts
+++ b/app/backend/src/routes/api/v4/vod.ts
@@ -90,8 +90,6 @@ export const vodRoute = app.get("/mapping/*", async (c) => {
       },
     ],
   };
-  console.log(JSON.stringify(mapping, null, 2));
-
   // Return raw JSON for nginx-vod-module compatibility
   return c.json(mapping);
 });

--- a/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
+++ b/z/2025-12-31-EXECPLAN-security-and-quality-fixes.md
@@ -62,8 +62,9 @@ This document must be maintained in accordance with `.agent/PLANS.md`.
   - Returns "Invalid token signature" error for tampered/invalid tokens
   - Created `app/backend/src/__tests__/jwt.test.ts` with 5 test cases
   - Verified: 23/23 tests passed
-- [ ] Milestone 8: デバッグログの削除
-  - `app/backend/src/routes/api/v4/vod.ts:93` の console.log を削除
+- [x] (2025-12-31 14:40 JST) Milestone 8: デバッグログの削除
+  - Removed `console.log(JSON.stringify(mapping, null, 2))` from `app/backend/src/routes/api/v4/vod.ts`
+  - Verified: 23/23 tests passed
 - [ ] Milestone 9: フロントエンドAPIエラーハンドリング改善
   - HTTPエラーステータスのチェック追加
   - ApiErrorクラスの導入


### PR DESCRIPTION
## Summary

VODマッピングエンドポイントからデバッグ用のconsole.logを削除しました。

## Changes

- `app/backend/src/routes/api/v4/vod.ts` から `console.log(JSON.stringify(mapping, null, 2));` を削除
- ExecPlanのProgress更新（Milestone 8完了）

## Background

このログはnginx-vod-moduleマッピングのデバッグ用に追加されていましたが、本番環境では不要であり、パフォーマンスに悪影響を与える可能性があるため削除します。

## Testing

- `pnpm test` で全23件のテストがパス
- TypeScriptコンパイル通過

## Related

Part of security and quality fixes (Milestone 8)
See: z/2025-12-31-EXECPLAN-security-and-quality-fixes.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed debug logging output from video-on-demand API route handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->