### PR TITLE
refactor: remove unnecessary useSearchParams subscription

### DIFF
--- a/app/frontend/src/app/login/page.tsx
+++ b/app/frontend/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { AuthForm, AuthLayout, FormField } from "@/components/Auth";
@@ -10,7 +10,6 @@ import { postAuth } from "@/service/postAuth";
 
 const LoginPage = () => {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { loading, error, startAuth, handleAuthSuccess, handleAuthError } =
     useAuth();
 
@@ -26,13 +25,15 @@ const LoginPage = () => {
       // Check if already authenticated
       const token = localStorage.getItem("token");
       if (token && token !== "null" && token.trim() !== "") {
-        const callback = searchParams?.get("callback");
+        const callback = new URLSearchParams(window.location.search).get(
+          "callback",
+        );
         router.push(callback ? decodeURIComponent(callback) : "/");
         return;
       }
       setInitialLoading(false);
     })();
-  }, [router, searchParams]);
+  }, [router]);
 
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/app/frontend/src/hooks/useAuth.ts
+++ b/app/frontend/src/hooks/useAuth.ts
@@ -1,19 +1,20 @@
 import { useSetAtom } from "jotai";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { AuthTokenAtom } from "@/atoms/Auth";
 
 export function useAuth() {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const setAuthToken = useSetAtom(AuthTokenAtom);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
   const handleAuthSuccess = (token: string) => {
     setAuthToken(token);
-    const callback = searchParams?.get("callback");
+    const callback = new URLSearchParams(window.location.search).get(
+      "callback",
+    );
     router.push(callback ? decodeURIComponent(callback) : "/");
   };
 


### PR DESCRIPTION
## 概要
`useSearchParams` の不要な購読を削除し、必要時にURLから直接パラメータを取得するように変更しました。

## 変更内容
- `LoginPage` から `useSearchParams` の購読を削除し、`window.location.search` から直接 `callback` パラメータを取得
- `useAuth` フックの `handleAuthSuccess` でも同様にURLから直接取得するように変更

## 効果
- 検索パラメータの変更による不要な再レンダーを防止
- Vercel React Best Practices の `rerender-defer-reads` ルールに準拠

## 関連
- Vercel React Best Practices: 5.1 Defer State Reads to Usage Point

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Replaced `useSearchParams` hook with direct URL parameter reading via `window.location.search` to prevent unnecessary component re-renders when search parameters change.

**Key changes:**
- `LoginPage` component: Removed `useSearchParams` import and usage, replaced with `new URLSearchParams(window.location.search)` in the `useEffect` hook
- `useAuth` hook: Removed `useSearchParams` import and usage, replaced with `new URLSearchParams(window.location.search)` in `handleAuthSuccess` function

**Technical correctness:**
- Both files use `"use client"` directive, ensuring client-side execution
- URL parameter reads occur only in client-side contexts (`useEffect` and post-authentication callback)
- The refactoring aligns with Vercel React Best Practices (5.1 Defer State Reads to Usage Point)

**Benefits:**
- Eliminates subscription to search parameter changes
- Prevents re-renders when URL query parameters change
- Reads parameters only when needed rather than maintaining a reactive subscription

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The refactoring is a straightforward performance optimization that correctly replaces a reactive hook subscription with direct URL reading. Both usages are in client components and execute only in client-side contexts, eliminating any SSR concerns. The change maintains identical functionality while reducing unnecessary re-renders.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/frontend/src/app/login/page.tsx | Removed `useSearchParams` subscription, now reads callback parameter directly from URL in `useEffect` |
| app/frontend/src/hooks/useAuth.ts | Removed `useSearchParams` subscription, now reads callback parameter directly from URL in `handleAuthSuccess` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant LoginPage
    participant useAuthHook
    participant Browser
    participant Router

    User->>LoginPage: Visit page with callback query param
    
    LoginPage->>Browser: Check if already logged in
    alt Already logged in
        LoginPage->>Browser: Read URL search params
        Browser-->>LoginPage: Return callback value
        LoginPage->>Router: Navigate to callback destination
    else Not logged in
        User->>LoginPage: Submit login form
        LoginPage->>useAuthHook: Invoke success handler
        useAuthHook->>Browser: Read URL search params
        Browser-->>useAuthHook: Return callback value
        useAuthHook->>Router: Navigate to callback destination
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - app/frontend/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=f0285935-3c2f-48fb-bc44-346dad78374c))

<!-- /greptile_comment -->