### PR TITLE
fix: ログインボタンからログインページ遷移時にコールバックURLを設定

### DIFF
--- a/app/frontend/src/app/login/page.tsx
+++ b/app/frontend/src/app/login/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 
 import { AuthForm, AuthLayout, FormField } from "@/components/Auth";
 import { SiteName } from "@/contexts/env";
-import { useAuth } from "@/hooks/useAuth";
+import { getSafeCallback, useAuth } from "@/hooks/useAuth";
 import { postAuth } from "@/service/postAuth";
 
 const LoginPage = () => {
@@ -26,8 +26,8 @@ const LoginPage = () => {
       // Check if already authenticated
       const token = localStorage.getItem("token");
       if (token && token !== "null" && token.trim() !== "") {
-        const callback = searchParams?.get("callback");
-        router.push(callback ? decodeURIComponent(callback) : "/");
+        const callback = getSafeCallback(searchParams?.get("callback") ?? null);
+        router.push(callback ?? "/");
         return;
       }
       setInitialLoading(false);

--- a/app/frontend/src/components/App/Header/Auth/AuthButton.tsx
+++ b/app/frontend/src/components/App/Header/Auth/AuthButton.tsx
@@ -1,6 +1,6 @@
 import { useSetAtom } from "jotai";
 import { LogIn, LogOut } from "lucide-react";
-import { useRouter } from "next/router";
+import { usePathname, useRouter } from "next/navigation";
 import { AuthTokenAtom } from "@/atoms/Auth";
 import { Button } from "@/components/ui/button";
 import { useSelf } from "@/hooks/useUser";
@@ -9,6 +9,7 @@ import { deleteAuth } from "@/service/deleteAuth";
 const AuthButton = () => {
   const user = useSelf();
   const router = useRouter();
+  const pathname = usePathname();
   const setAuthToken = useSetAtom(AuthTokenAtom);
 
   // biome-ignore lint/suspicious/noExplicitAny: type inference
@@ -33,7 +34,8 @@ const AuthButton = () => {
     <Button
       variant={"ghost"}
       onClick={() => {
-        void router.push("/login");
+        const callback = encodeURIComponent(pathname);
+        void router.push(`/login?callback=${callback}`);
       }}
       size={"icon"}
       className="cursor-pointer"

--- a/app/frontend/src/components/App/Header/Auth/AuthButton.tsx
+++ b/app/frontend/src/components/App/Header/Auth/AuthButton.tsx
@@ -34,7 +34,7 @@ const AuthButton = () => {
     <Button
       variant={"ghost"}
       onClick={() => {
-        const callback = encodeURIComponent(pathname);
+        const callback = encodeURIComponent(pathname || "/");
         void router.push(`/login?callback=${callback}`);
       }}
       size={"icon"}

--- a/app/frontend/src/hooks/useAuth.ts
+++ b/app/frontend/src/hooks/useAuth.ts
@@ -4,6 +4,25 @@ import { useState } from "react";
 
 import { AuthTokenAtom } from "@/atoms/Auth";
 
+export const getSafeCallback = (callback: string | null) => {
+  if (!callback) {
+    return null;
+  }
+  try {
+    const decoded = decodeURIComponent(callback);
+    if (
+      decoded.startsWith("/") &&
+      !decoded.startsWith("//") &&
+      !decoded.includes("://")
+    ) {
+      return decoded;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+};
+
 export function useAuth() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -13,8 +32,8 @@ export function useAuth() {
 
   const handleAuthSuccess = (token: string) => {
     setAuthToken(token);
-    const callback = searchParams?.get("callback");
-    router.push(callback ? decodeURIComponent(callback) : "/");
+    const callback = getSafeCallback(searchParams?.get("callback") ?? null);
+    router.push(callback ?? "/");
   };
 
   const handleAuthError = (message?: string) => {


### PR DESCRIPTION
## 概要
右上のログインボタンを押した際に、現在のページURLをコールバックパラメータとしてログインページに渡すように修正しました。

## 変更内容
- `AuthButton.tsx`で`next/navigation`の`usePathname`を使用して現在のパスを取得
- ログインページへの遷移時に`/login?callback=<エンコード済みパス>`の形式でURLを構築
- ログイン成功後、`useAuth.ts`の`handleAuthSuccess`関数がコールバックURLを読み取り、元のページにリダイレクト

## 関連する問題
ログインボタンからログインページへ遷移した後、ログイン成功時に元のページに戻れない問題を修正



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users are now redirected back to their original page after logging in, preserving their browsing context and improving navigation flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR implements callback URL handling for login redirection, allowing users to return to their original page after authentication. The changes introduce a `getSafeCallback` validation function that properly prevents open redirect vulnerabilities by verifying that decoded callback URLs are internal paths (start with `/` and don't contain protocol schemes). The implementation also updates `AuthButton.tsx` to use the modern `next/navigation` API instead of the deprecated `next/router`.

**Key improvements:**
- Adds callback URL capture in login button to preserve user navigation context
- Implements secure callback validation with protocol and double-slash checks
- Fixes deprecated Next.js router usage (next/router → next/navigation)
- Applies validation consistently across login page and auth handler

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified issues. Security validation for callback URLs has been properly implemented.
- The PR successfully addresses the open redirect vulnerability flagged in the previous review by implementing comprehensive callback URL validation. The `getSafeCallback` function properly validates that URLs are internal paths, preventing protocol-based and double-slash redirects. All changes follow the project's architecture guidelines, use the correct Next.js 14 APIs, and maintain type safety. Code quality is high with no regressions or new issues introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/frontend/src/components/App/Header/Auth/AuthButton.tsx | Updated to use `next/navigation` instead of deprecated `next/router` and now captures the current pathname before redirecting to login. Uses `encodeURIComponent` to safely encode the path as a query parameter. |
| app/frontend/src/hooks/useAuth.ts | Added `getSafeCallback` function that properly validates callback URLs to prevent open redirect vulnerabilities. Validates that decoded URLs start with `/` and don't contain protocol schemes (`://`, `//`). Both `handleAuthSuccess` in useAuth and the login page now use this validation. |
| app/frontend/src/app/login/page.tsx | Updated to use `getSafeCallback` for callback URL validation. When user is already authenticated, the callback is now validated before redirecting. This prevents potential open redirect attacks. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AuthButton
    participant LoginPage
    participant Handler

    User->>AuthButton: Login clicked
    AuthButton->>AuthButton: Get pathname
    AuthButton->>LoginPage: Navigate with callback param
    User->>LoginPage: Enter credentials
    LoginPage->>Handler: Auth success
    Handler->>Handler: Validate callback
    Handler->>User: Redirect
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - app/frontend/CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=f0285935-3c2f-48fb-bc44-346dad78374c))

<!-- /greptile_comment -->