### PR TITLE
fix: include next.config.js in Dockerfile for frontend build

### DIFF
--- a/app/frontend/Dockerfile
+++ b/app/frontend/Dockerfile
@@ -38,6 +38,7 @@ COPY --from=builder /app/app/frontend/.next/standalone ./
 COPY --from=builder /app/app/frontend/public ./app/frontend/public
 COPY --from=builder /app/app/frontend/.next/static ./app/frontend/.next/static
 COPY --from=builder /app/app/frontend/start.sh ./
+COPY app/frontend/next.config.js ./app/frontend/next.config.js
 
 COPY app/frontend/docker/.env.placeholder ./.env
 COPY app/frontend/docker/env-replacer.sh ./


### PR DESCRIPTION
`"url" parameter is not allowed`が発生するため原因と思われるnext.config.jsを追加
おそらくstandaloneのコピーの都合で欠落している可能性が高い
ref: https://zenn.dev/thaddeusjiang/articles/b4427f448c11e1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the deployment process to ensure application configuration files are properly included in the production container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `next.config.js` to the runtime Docker image by copying it from the build context directly to the runner stage. This ensures the Next.js configuration file is available at runtime in the production container.

- Copies `next.config.js` to `./app/frontend/next.config.js` in the runtime container

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple file copy operation that doesn't modify any application logic. While Next.js standalone builds typically bundle configuration at build time, including the config file explicitly may be needed for specific runtime scenarios or was added to resolve a production issue.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/frontend/Dockerfile | Adds `next.config.js` copy to runtime stage - likely unnecessary for standalone builds as config is already baked in |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant BC as Build Context
    participant Builder as Builder Stage
    participant Runner as Runner Stage
    participant Container as Running Container

    BC->>Builder: Copy package files
    Builder->>Builder: Install dependencies (pnpm)
    BC->>Builder: Copy source code
    Builder->>Builder: Generate Prisma client
    Builder->>Builder: Build Next.js (standalone)
    
    Builder->>Runner: Copy .next/standalone
    Builder->>Runner: Copy public assets
    Builder->>Runner: Copy .next/static
    Builder->>Runner: Copy start.sh
    BC->>Runner: Copy next.config.js [NEW]
    BC->>Runner: Copy .env.placeholder
    BC->>Runner: Copy env-replacer.sh
    
    Runner->>Runner: Set permissions on scripts
    Runner->>Container: Start with env-replacer.sh
    Container->>Container: Execute start.sh
    Container->>Container: Run Next.js server (server.js)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->