### PR TITLE
fix: remove native hls

### DIFF
--- a/app/frontend/src/components/Player/Shared/Video.tsx
+++ b/app/frontend/src/components/Player/Shared/Video.tsx
@@ -106,10 +106,7 @@ const Video = ({ className, videoRef, movie }: props) => {
 
   const loadVideo = useCallback(
     (video: HTMLVideoElement, url: string) => {
-      if (video.canPlayType("application/vnd.apple.mpegurl")) {
-        video.src = url;
-        video.crossOrigin = "use-credentials";
-      } else if (Hls.isSupported()) {
+      if (Hls.isSupported()) {
         const hls = new Hls({
           xhrSetup: (xhr, url) => {
             xhr.open("GET", url);

--- a/app/frontend/src/components/Player/Shared/Video.tsx
+++ b/app/frontend/src/components/Player/Shared/Video.tsx
@@ -107,6 +107,10 @@ const Video = ({ className, videoRef, movie }: props) => {
   const loadVideo = useCallback(
     (video: HTMLVideoElement, url: string) => {
       if (Hls.isSupported()) {
+        if (hlsRef.current) {
+          hlsRef.current.destroy();
+          hlsRef.current = null;
+        }
         const hls = new Hls({
           xhrSetup: (xhr, url) => {
             xhr.open("GET", url);

--- a/app/frontend/src/components/Player/Shared/Video.tsx
+++ b/app/frontend/src/components/Player/Shared/Video.tsx
@@ -121,6 +121,7 @@ const Video = ({ className, videoRef, movie }: props) => {
         hls.attachMedia(video);
         hlsRef.current = hls;
         video.crossOrigin = "anonymous";
+        video.disableRemotePlayback = true;
       } else {
         console.error(
           "This is an old browser that does not support MSE https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API",


### PR DESCRIPTION
- hlsjsの使用を強制
- 認証をcookieからauthorizationヘッダーに移行した関係でcredentials=includeだと認証に失敗するようになっていたため

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified HLS playback across browsers for more consistent and reliable video streaming.
  * Added support for token-based authenticated streams so secured content loads when authorized.
  * Disabled remote playback to prevent streaming to external devices.
  * Removed legacy browser-specific fallback logic to simplify and stabilize playback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Removed native HLS playback support (Safari) to enforce hls.js usage across all browsers, ensuring consistent token-based authentication via Authorization headers instead of cookies.

## Key Changes
- Removed Safari's native HLS playback path that used `video.canPlayType("application/vnd.apple.mpegurl")` and `crossOrigin = "use-credentials"`
- Now forces all browsers to use hls.js with token-based auth via `Authorization: Bearer ${token}` header
- Added proper HLS instance cleanup before creating new instance to prevent memory leaks
- Set `crossOrigin = "anonymous"` since authentication is now header-based, not cookie-based
- Added `disableRemotePlayback = true` to prevent casting to external devices

## Issues Found
- Two useEffect hooks have incorrect dependencies (`videoRef.current` instead of `videoRef`) that don't follow React Hook rules

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor React Hook dependency issues that should be fixed
- The core logic change is sound - removing native HLS support to enforce hls.js usage resolves the authentication issue. The HLS instance cleanup prevents memory leaks. However, two useEffect hooks have incorrect dependencies (videoRef.current instead of videoRef) that violate React Hook rules and could cause unexpected behavior.
- app/frontend/src/components/Player/Shared/Video.tsx needs attention for useEffect dependency issues on lines 142 and 147

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/frontend/src/components/Player/Shared/Video.tsx | Removed native HLS support to force hls.js usage, migrated from cookie-based auth to Authorization header, added HLS instance cleanup and disabled remote playback |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant VideoComponent
    participant HLS.js
    participant VideoElement
    participant API

    User->>VideoComponent: Load video content
    VideoComponent->>VideoComponent: Check Hls.isSupported()
    
    alt HLS instance exists
        VideoComponent->>HLS.js: destroy()
        VideoComponent->>VideoComponent: hlsRef.current = null
    end
    
    VideoComponent->>HLS.js: new Hls({xhrSetup})
    Note over HLS.js: Configure with token-based auth
    
    VideoComponent->>HLS.js: loadSource(url)
    HLS.js->>API: GET HLS manifest with Authorization header
    API-->>HLS.js: Return manifest
    
    VideoComponent->>HLS.js: attachMedia(video)
    HLS.js->>VideoElement: Attach media source
    
    VideoComponent->>VideoElement: crossOrigin = "anonymous"
    VideoComponent->>VideoElement: disableRemotePlayback = true
    
    HLS.js->>API: GET video segments with Authorization header
    API-->>HLS.js: Return segments
    
    HLS.js->>VideoElement: Feed video data
    VideoElement-->>User: Play video
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->